### PR TITLE
feat: optional voice-sample calibration for edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ You get back the edited draft plus a short What changed section. The skill makes
 
 You get every pattern it found each with the quoted line.
 
+**3. Calibrate to your voice (optional).** Paste a past post or email with your draft:
+
+```
+/no-ai-slop here are two posts I wrote, then my draft
+
+[your past writing]
+
+[your past writing]
+
+[your draft]
+```
+
 ## Files
 
 1. `SKILL.md`: The editing rules and workflow.

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,9 +21,11 @@ If the audience or format is unclear, ask one question: Who is this for and wher
 
 If the goal is unclear, ask what the reader should think, feel, or do after reading it.
 
+If the user includes past writing alongside the draft (an earlier post, email, or article), treat it as voice samples: derive voice signals from the samples and the draft together. Do not ask for samples up front. If the draft is under roughly 150 words and its voice is thin, you may offer once: "Want to paste a past post or email so the edit keeps your voice?" Proceed without samples if the user declines or does not answer.
+
 ## Editing principles
 
-- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency.
+- **Preserve the writer's real voice.** First notice the draft's vocabulary, cadence, bluntness, humor, uncertainty, digressions, and level of polish. Keep the traits that feel personal to the writer. Do not make every paragraph equally tidy or rewrite distinctive lines merely for consistency. When voice samples are provided, notice their vocabulary, cadence, sentence length, bluntness, humor, and pet phrases, and weigh them alongside the draft. Samples inform style only: never import claims, examples, stats, or phrases from a sample into the draft.
 - **Make the minimum effective edit.** Fix AI patterns, errors, repetition, and unclear passages. Leave strong human sentences alone. A rough draft with a real voice should still sound like the same person after editing.
 - **Lead with the point when the setup adds nothing.** Cut generic throat-clearing. Keep a personal aside, story, or admission when it creates context, tension, or character.
 - **Front-load only when it improves clarity.** Put conclusions early when that helps the reader. Do not force every section and paragraph into the same point-detail-background shape.
@@ -86,8 +88,8 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 ## Workflow
 
 1. Read the full draft before editing.
-2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If voice samples were provided, derive the voice-signal note from the samples plus the draft and keep track of which signals came from samples. If you cannot identify the core point, ask the user.
 3. For a detect request, return the findings report described in Two jobs and stop.
 4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
 5. If any check fails, fix the draft and run the checks again.
-6. Output the full edited draft and a short **What changed** section.
+6. Output the full edited draft and a short **What changed** section. If voice samples informed the edit, say so.

--- a/eval.md
+++ b/eval.md
@@ -16,6 +16,8 @@ For detect requests, make sure the response names each pattern found with a quot
 8. Does the draft use active voice with human subjects where possible?
 9. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
 10. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
+11. If voice samples were provided, does the edit match their cadence and vocabulary without copying any content, claims, or phrases from the samples into the draft?
+12. If no samples were provided, was the edit made normally without demanding them?
 
 ## Words to cut
 


### PR DESCRIPTION
Short drafts give the editor almost no voice evidence. The skill derives voice signals only from the draft being edited, so a tweet-length draft tends to come back as tidy generic prose, the exact failure this skill exists to prevent.

This PR adds an optional voice-samples input to edit mode. Paste a past post or email with your draft and the skill derives voice signals from the samples plus the draft. Samples inform style only, never content. With no samples, behavior is unchanged.

**Changes**

- `SKILL.md`: treat pasted past writing as voice samples in "What to ask for", weigh sample traits in the voice-preservation principle, and derive the voice-signal note from samples plus draft in workflow step 2
- `eval.md`: two new checks covering sample-informed edits and the no-sample default
- `README.md`: third Use example showing the optional paste-along flow

**Example** (40-word draft)

Without samples the edit reads "Last night we shipped a significant rewrite of the tracker. Performance has improved considerably." With two past posts pasted, the same edit keeps the writer's cadence: "shipped the tracker rewrite last night. it's fast now. genuinely fast. bundle cut in half, three deps gone."

**Simulated Demo**

![voice sample calibration demo](https://raw.githubusercontent.com/mvanhorn/no-ai-slop/evidence-assets/voice-calibration.gif)
