### PR TITLE
Add structural AI-slop patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # No AI slop
 
-This skill removes 20+ patterns of AI slop from your writing and it can also help you detect slop as well.
+This skill removes 40+ patterns of AI slop from your writing and it can also help you detect slop as well.
 
 ## What it catches
 
@@ -19,6 +19,14 @@ The patterns it detects include:
 | Synonym cycling | the agent, then the assistant, then the tool |
 | Negative listing | "Not a X. Not a Y. A Z." |
 | Dramatic fragmentation | "That's it. That's the whole thing." |
+| Anaphora | "Every tree, every field, every sign..." |
+| Transformation pivots | "X becomes Y" / "X is turning into Y" |
+| Parallel declarative stacks | Reorderable `[noun] [verb] [noun]` assertion grids |
+| Abstract framing | "The problem was X." / "The key insight is..." |
+| Forced optimism endings | "Despite these challenges, the future remains bright." |
+| Hedging clusters | "arguably... in many ways... to some extent..." |
+
+It also catches label sentences, stacked tail clauses, mixed-vehicle metaphors, noun-inventory subjects, point-announcing lead-ins, harder-question escalations, forced triads, comma-list overload, nominalization stacks, repetition disguised as development, automatic moral lessons, sanitized story arcs, generic specificity, chatbot tells, and unproved superlatives. See [SKILL.md](SKILL.md) for the full list.
 
 It also enforces the fundamentals that make writing good: Lead with the point when it helps, use active voice, untangle hard-to-follow sentences, and prefer concrete numbers over abstractions.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,50 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
 
+**Anaphora.** "Every tree, every field, every sign that anything had existed." Repeating a word at the start of three or more parallel clauses sounds like a speech. Collapse to one plain sentence: "Nothing was left above the surface." Watch for every/every/every, no/no/no, each/each/each.
+
+**Label sentences.** A 3–6 word sentence that only names a pattern already visible nearby: "Three capacity tracks." "One entity per track." Cut it, or fold the label into the sentence that carries the fact.
+
+**Stacked tail clauses.** An already-complete sentence with a second qualifying or locative phrase tacked on after a comma, especially a metaphor callback: "That is where value collects once answers are cheap, at the edges the sand does not reach." End the sentence when the claim lands. Give the callback its own sentence, or cut it.
+
+**Mixed-vehicle metaphors.** One sentence that forces two or three unrelated physical pictures at once. If you need "and" to name a second scene the reader must picture, cut one vehicle. Prefer plain claim over a fresh landscape invented for one line.
+
+**Mirrored explanation pairs.** "The first strategy buys depth. The second buys coverage." Matching grammar that categorizes instead of explaining. Name the relationship in one sentence.
+
+**Parallel declarative stacking.** Three or more sentences in a row built as `[noun] [verb] [noun]` with no connective, reorderable without changing meaning. Merge into a sentence that states how the pieces relate, or cut the weakest assertion.
+
+**Noun inventory subjects.** Five or more nouns front-loaded as a comma subject before a weak predicate ("remain separate requirements," "are factors," "matter"). Collapse to the constraint that actually limits the outcome.
+
+**Abstract framing.** "The problem was X." "The challenge is…" "The key insight is…" "The reality is…" These announce a category instead of showing the concrete thing. Start with what was actually true.
+
+**Point-announcing lead-ins.** "The number carries the point." "This detail proves it." "Here is what changed." Delete the announcement and let the fact open the sentence.
+
+**Harder-question escalations.** "X will happen. The harder question is Y." Labels depth instead of delivering it. Ask Y directly, or state the harder claim directly. Cut "the harder/real/bigger/deeper question/part/challenge/problem/issue is."
+
+**Transformation pivots.** "X stops being Y and becomes Z." "X becomes Z." "X is turning into Z." Including in headings. State the end state as a fact, or name the event that caused the change. "The marvel becomes a commodity" becomes "The marvel is already priced for everyone," or name what changed the price.
+
+**Forced rule of three.** "Clear, compelling, and transformative." AI pads 1–2 real items into a polished triad. Let the evidence set the count. One accurate item beats three padded ones.
+
+**Comma-list overload.** Inline lists of 5+ items the reader cannot hold. Cap at 3, occasionally 4 when every item is load-bearing. Past that, group into higher-level components rather than deleting real items. Never stack two lists in one sentence.
+
+**Nominalization stacks.** "The implementation of X facilitates the optimization of Y." Turn the noun back into a verb and name who acts: "A weekly review helps the team decide."
+
+**Repetition disguised as development.** Claim, expanded claim, metaphorical restatement, "in other words," summary. Each paragraph must add evidence, a mechanism, an example, a qualification, an objection, a consequence, or an inference. If it only restates, delete it.
+
+**Forced optimism endings.** "Despite these challenges, the future remains bright." Unearned hopeful closes. End on the result, the cost, the open question, or the next action.
+
+**Automatic moral lessons.** "This story reminds us that true progress is possible only when…" Do not append a moral the author did not write. Show the decision and its cost; let the reader conclude.
+
+**Sanitized story arcs.** Manageable conflict, reconciliation, lesson, stability restored. Preserve what actually happened: irreversible costs, mixed motives, unfair outcomes, unresolved disagreement.
+
+**Generic specificity.** "The vibrant community celebrates its rich heritage while embracing modernity." Sounds specific, names nothing. Replace atmosphere with a particular object, phrase, place, disagreement, or awkward detail.
+
+**Hedging clusters.** Several of "arguably," "in many ways," "to some extent," "may well," "it seems that," "broadly speaking" in one piece. One hedge can be honest. A cluster is fear of commitment. Commit to the claim; qualify only with a named doubt.
+
+**Chatbot tells.** "Certainly," "Absolutely," "I'd be happy to," "Great question," or restating the user's question before answering. Cut them and answer.
+
+**Unproved superlatives.** "Largest," "first," "best," "world-class," "unique" without evidence. Use the specific fact, or cut the claim.
+
 ## Workflow
 
 1. Read the full draft before editing.

--- a/eval.md
+++ b/eval.md
@@ -31,6 +31,12 @@ For detect requests, make sure the response names each pattern found with a quot
 6. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
 7. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
 8. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+9. Are anaphora, label sentences, stacked tail clauses, mixed-vehicle metaphors, and mirrored explanation pairs fixed?
+10. Are parallel declarative stacks, noun-inventory subjects, abstract framing, point-announcing lead-ins, and harder-question escalations removed?
+11. Are transformation pivots (including in headings), forced triads, comma-list overload, and nominalization stacks rewritten into concrete claims?
+12. Does every paragraph pass the contribution test, with no repetition disguised as development?
+13. Are forced optimism endings, automatic moral lessons, and sanitized story arcs cut in favor of the real result, cost, or open question?
+14. Are generic specificity, hedging clusters, chatbot tells, and unproved superlatives removed or replaced with named facts?
 
 ## Final read
 


### PR DESCRIPTION
## Summary

Adds structural and rhetorical AI-slop tells that the current skill's surface patterns miss. Battle-tested in a bilingual engineering blog ruleset (cut-lists used on real posts, not theory).

New patterns in `SKILL.md`:

- Anaphora (every/every/every)
- Label sentences ("Three capacity tracks.")
- Stacked tail clauses
- Mixed-vehicle metaphors
- Mirrored explanation pairs ("The first… The second…")
- Parallel declarative stacking
- Noun inventory subjects
- Abstract framing ("The problem was X")
- Point-announcing lead-ins ("The number carries the point")
- Harder-question escalations
- Transformation pivots ("X becomes Y", including headings)
- Forced rule of three
- Comma-list overload
- Nominalization stacks
- Repetition disguised as development (contribution test)
- Forced optimism endings
- Automatic moral lessons
- Sanitized story arcs
- Generic specificity
- Hedging clusters
- Chatbot tells
- Unproved superlatives

Also extends `eval.md` with matching pass/fail checks and updates the README catch table with representative rows.

## Out of scope (intentionally)

- No change to the soft em-dash policy (1–2 allowed in longer drafts)
- No personal/identity rules, bilingual rules, or craft-structure advice (how to open a post, problem/solution ratio). Those belong in a writing skill, not a slop detector.

## Test plan

- [ ] Run `/no-ai-slop` on a draft that uses "X becomes Y" and "The problem was X"; confirm both are rewritten
- [ ] Run detect mode on a piece with hedging clusters; confirm quoted lines, no rewrite
- [ ] Confirm existing patterns (binary contrasts, colon reveals, em dashes) still behave as before


Made with [Cursor](https://cursor.com)