### PR TITLE
docs: add limits and contributing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Keep changes small and easy to review.
+
+Good changes usually do one of these:
+
+- Clarify an existing rule in `skills/no-ai-slop/SKILL.md` without changing its behavior.
+- Add a missing example for a pattern already in `skills/no-ai-slop/SKILL.md`.
+- Add a new pattern with a clear smell, a plain fix, and a short before/after example.
+- Update `skills/no-ai-slop/eval.md` when the skill behavior changes.
+
+Before opening a PR, check:
+
+- Does the change preserve the writer's voice instead of making every draft sound polished?
+- Does it avoid guessing whether AI wrote something?
+- Does detect mode still return pattern evidence, not a rewrite or score?
+- Does the README stay short enough for new users to understand quickly?
+- Does the PR avoid unrelated cleanup?
+
+If you add a pattern, include the smallest useful example. One sharp example beats a long list.


### PR DESCRIPTION
Adds a short Limits section to make clear that detect mode flags writing patterns, not authorship.

Also adds CONTRIBUTING.md with a small review checklist for future rule and docs changes.

Changes:
- clarify that the skill is not an AI detector
- warn against using findings to accuse someone of using AI
- add contribution guidance for new patterns, examples, and eval updates