### PR TITLE
Unicode-to-ASCII and generic-fluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The patterns it detects include:
 | Synonym cycling | the agent, then the assistant, then the tool |
 | Negative listing | "Not a X. Not a Y. A Z." |
 | Dramatic fragmentation | "That's it. That's the whole thing." |
+| Unicode stand-ins | curly quotes, "fancy" dashes, invisible spaces, → and × |
 
 It also enforces the fundamentals that make writing good: Lead with the point when it helps, use active voice, untangle hard-to-follow sentences, and prefer concrete numbers over abstractions.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,40 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
 
+**Unicode characters.** AI drafts leak "smart" Unicode where plain ASCII was meant: curly quotes, fancy dashes, ellipsis glyphs, invisible spaces, and math or arrow symbols. For each one, ask a simple question: is this normal Unicode that can be replaced with ASCII, or does it genuinely need to be Unicode and is what the writer meant (a real name, a quoted source, a language that uses it, a math or code context where the exact glyph matters)? If it must stay, leave it. Otherwise replace it with the ASCII equivalent below.
+
+| Character | Code point | Replace with |
+|-----------|-----------|--------------|
+| `‘` | U+2018 | `'` |
+| `’` | U+2019 | `'` |
+| `“` | U+201C | `"` |
+| `”` | U+201D | `"` |
+| `‐` | U+2010 | `-` |
+| `‑` | U+2011 | `-` |
+| `–` | U+2013 | `-` |
+| `—` | U+2014 | `-` |
+| `−` | U+2212 | `-` |
+| `…` | U+2026 | `...` |
+| `•` | U+2022 | `-` or `*` |
+| `·` | U+00B7 | `.` |
+| ` ` (no-break space) | U+00A0 | normal space |
+| ` ` (narrow no-break space) | U+202F | normal space |
+| ` ` (thin space) | U+2009 | normal space |
+| zero-width space | U+200B | remove |
+| zero-width non-joiner | U+200C | remove |
+| zero-width joiner | U+200D | remove |
+| byte-order mark | U+FEFF | remove |
+| `→` | U+2192 | `->` |
+| `←` | U+2190 | `<-` |
+| `⇒` | U+21D2 | `=>` |
+| `≤` | U+2264 | `<=` |
+| `≥` | U+2265 | `>=` |
+| `≠` | U+2260 | `!=` |
+| `×` | U+00D7 | `*` |
+| `÷` | U+00F7 | `/` |
+| `／` | U+FF0F | `/` |
+| `：` | U+FF1A | `:` |
+
 ## Workflow
 
 1. Read the full draft before editing.

--- a/SKILL.md
+++ b/SKILL.md
@@ -51,6 +51,8 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
 
+**Reveal setups.** A generic noun-phrase lead-in that delays a point the sentence could state directly: "The fix is not a faster reader. It is AI doing the first pass." / "The answer is not to pick one provider, it is to make the model swappable." / "The problem is not the tool." Formulas like "The fix is," "The answer is," "The problem is," "The hard part is," "The real question is" promise a reveal and pad the delivery. Cut the setup and state the point: "The fix is not a faster reader, it is a first pass by AI" becomes "Let AI do the first pass so the reader only checks it."
+
 **Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
 
 **Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
@@ -71,9 +73,21 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
 
+**Dramatic defining-relatives.** "The risk that sinks you is the one nobody logged." / "The clause that burns you is the one you skimmed." / "The thing that matters is the thing you missed." The "the X that [does something to you]" frame builds suspense around a plain subject. Name the thing and say what about it matters: "The clause that burns you is the one you skimmed" becomes "You skim the clause that later costs you."
+
+**Transformation cliches.** "It stops being a document and becomes a task." / "The report turns into a liability." / "That is when data becomes evidence." The becomes/turns-into/stops-being frame dramatizes an ordinary change of state. Describe the change directly, or cut it if nothing actually changes: "A framework stops being a PDF and becomes a to-do list" becomes "Turn each obligation in the framework into a task with an owner."
+
+**Confidence flourishes.** "delivered with total confidence," "with no second opinion," "sounds sure," "confident guess dressed as a fact." Tacking a "with total confidence" tail onto a claim is decoration. State what happened: "The model answers with total confidence" becomes "The model gives the same fluent answer whether it is right or wrong."
+
 **Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
 
 **Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Self-pointing "that is" claims.** "That is exactly why they are dangerous," "That is what happens when nobody checks," "That is the point." The sentence points back at itself to announce its own significance instead of just stating the next fact. Cut the pointer and connect the idea plainly: "Agents act on instructions. That is exactly why they are dangerous" becomes "Agents act on instructions, which is what makes them dangerous." Watch "exactly" as the tell here and on its own: "exactly where the loss hides," "exactly the claim that needs a human." It manufactures precision the sentence has not earned. Cut it unless it marks a genuinely specific point.
+
+**Manufactured payoffs.** "That is the difference between X and Y," "the line between X and Y," "the difference is Z." The frame inflates an ordinary distinction into a revelation. State the distinction directly: "That is the difference between a guess and an answer worth reviewing" becomes "A reviewed answer is worth more than a guess."
+
+**Reification metaphors.** Mid-draft figurative swaps that dress a plain fact as a clever image: "a liability with good grammar," "obligations wearing a document costume," "a data graveyard," "where deals go to wait." This is the fake-profound kicker moved off the final line, so treat it the same way. Replace the metaphor with the literal point ("obligations wearing a document costume" becomes "obligations buried in a PDF nobody acts on"), unless the image is genuinely the writer's own and earns its place.
 
 **Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
 

--- a/eval.md
+++ b/eval.md
@@ -32,6 +32,10 @@ For detect requests, make sure the response names each pattern found with a quot
 7. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
 8. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
 9. Are Unicode characters that stand in for plain ASCII (curly quotes, fancy dashes, ellipsis glyphs, invisible spaces, math and arrow symbols) replaced with their ASCII equivalents, and left as Unicode only where the glyph is genuinely meant?
+10. Are reveal setups ("The fix is," "The answer is," "The problem is," "The hard part is") cut or turned into a direct statement?
+11. Are self-pointing "that is" claims ("that is exactly why," "that is what happens when") and manufactured payoffs ("the difference between X and Y," "the line between X and Y") replaced with the plain point, and is a bare "exactly" cut where it manufactures precision the sentence has not earned?
+12. Are dramatic defining-relatives ("the risk that sinks you," "the clause that burns you"), transformation cliches ("becomes a," "stops being a," "turns into a"), and confidence flourishes ("with total confidence," "with no second opinion") replaced with direct statements?
+13. Are mid-text reification metaphors ("a liability with good grammar," "obligations wearing a document costume," "a data graveyard") replaced with the literal point unless the image is genuinely the writer's own?
 
 ## Final read
 

--- a/eval.md
+++ b/eval.md
@@ -31,6 +31,7 @@ For detect requests, make sure the response names each pattern found with a quot
 6. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
 7. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
 8. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+9. Are Unicode characters that stand in for plain ASCII (curly quotes, fancy dashes, ellipsis glyphs, invisible spaces, math and arrow symbols) replaced with their ASCII equivalents, and left as Unicode only where the glyph is genuinely meant?
 
 ## Final read
 


### PR DESCRIPTION
Hi,

Thanks for the great project, I added a matching eval check and two new patterns:
- Rule to swap Unicode for plain ASCII unless the glyph is meant
- More patterns: dramatic defining-relatives, transformation cliches, confidence flourishes, and mid-text reification metaphors.

Bests, Ali.