### PR TITLE
docs: add Spanish README translation

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,66 @@
+# No AI slop
+
+[English](README.md) | Español
+
+Esta skill elimina más de 20 patrones de "AI slop" de tus textos y también puede ayudarte a detectarlos.
+
+## Qué detecta
+
+Los patrones que detecta incluyen:
+
+| Patrón | Suena a |
+|--------|---------|
+| Contrastes binarios | "No es X. Es Y." |
+| Aperturas que dan rodeos | "Seamos honestos..." |
+| Falsos insights | "Lo que nadie te dice..." |
+| Revelación con dos puntos | "Lo mejor de todo: aprende solo." |
+| Análisis superficial | "...reflejando el compromiso del equipo" |
+| Grandilocuencia | "marca un antes y un después" |
+| Atribución vaga | "los expertos coinciden", "los estudios demuestran" |
+| Verbos falsamente fuertes | "funge como un eje central" |
+| Rotación de sinónimos | el agente, luego el asistente, luego la herramienta |
+| Listado negativo | "No es un X. No es un Y. Es un Z." |
+| Fragmentación dramática | "Eso es todo. Así de simple." |
+
+También refuerza los fundamentos de la buena escritura: ir al punto cuando ayuda, usar voz activa, desenredar oraciones difíciles de seguir y preferir números concretos sobre abstracciones.
+
+## Instalación
+
+Pega esto en Claude Code, Codex o tu harness de AI favorito:
+
+"Install this skill globally: [https://github.com/petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop)"
+
+## Uso
+
+**1. Editar un borrador.** Pégalo e invoca la skill:
+
+```
+/no-ai-slop
+
+[tu borrador]
+```
+
+Recibes el borrador editado más una sección breve de qué cambió. La skill hace la edición mínima efectiva y luego revisa su propio trabajo contra [eval.md](eval.md).
+
+**2. Detectar slop.** Pregunta si un texto suena a AI:
+
+```
+/no-ai-slop is this AI slop?
+
+[el texto]
+```
+
+Recibes cada patrón encontrado, cada uno con la línea citada.
+
+## Archivos
+
+1. `SKILL.md`: las reglas de edición y el flujo de trabajo.
+2. `eval.md`: checks de pasa/falla que la skill corre sobre sus propias ediciones.
+
+## Quién hizo esto
+
+Esta es una skill de mi sistema operativo personal de AI. La biblioteca completa, incluyendo mis cursos y flujos de trabajo, vive en [Behind the Craft](https://behindthecraft.com).
+
+## Licencia
+
+MIT

--- a/README.es.md
+++ b/README.es.md
@@ -13,7 +13,7 @@ Los patrones que detecta incluyen:
 | Contrastes binarios | "No es X. Es Y." |
 | Aperturas que dan rodeos | "Seamos honestos..." |
 | Falsos insights | "Lo que nadie te dice..." |
-| Revelación con dos puntos | "Lo mejor de todo: aprende solo." |
+| Revelaciones con dos puntos | "Lo mejor de todo: aprende solo." |
 | Análisis superficial | "...reflejando el compromiso del equipo" |
 | Grandilocuencia | "marca un antes y un después" |
 | Atribución vaga | "los expertos coinciden", "los estudios demuestran" |
@@ -22,11 +22,11 @@ Los patrones que detecta incluyen:
 | Listado negativo | "No es un X. No es un Y. Es un Z." |
 | Fragmentación dramática | "Eso es todo. Así de simple." |
 
-También refuerza los fundamentos de la buena escritura: ir al punto cuando ayuda, usar voz activa, desenredar oraciones difíciles de seguir y preferir números concretos sobre abstracciones.
+También refuerza los fundamentos de la buena escritura: ir al grano cuando ayuda, usar voz activa, desenredar oraciones difíciles de seguir y preferir números concretos sobre abstracciones.
 
 ## Instalación
 
-Pega esto en Claude Code, Codex o tu harness de AI favorito:
+Pega esto en Claude Code, Codex o tu harness de IA favorito:
 
 "Install this skill globally: [https://github.com/petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop)"
 
@@ -55,11 +55,11 @@ Recibes cada patrón encontrado, cada uno con la línea citada.
 ## Archivos
 
 1. `SKILL.md`: las reglas de edición y el flujo de trabajo.
-2. `eval.md`: checks de pasa/falla que la skill corre sobre sus propias ediciones.
+2. `eval.md`: checks pasa/falla que la skill corre sobre sus propias ediciones.
 
 ## Quién hizo esto
 
-Esta es una skill de mi sistema operativo personal de AI. La biblioteca completa, incluyendo mis cursos y flujos de trabajo, vive en [Behind the Craft](https://behindthecraft.com).
+Esta es una skill de mi sistema operativo personal de IA. La biblioteca completa, incluyendo mis cursos y flujos de trabajo, vive en [Behind the Craft](https://behindthecraft.com).
 
 ## Licencia
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # No AI slop
 
+English | [Español](README.es.md)
+
 This skill removes 20+ patterns of AI slop from your writing and it can also help you detect slop as well.
 
 ## What it catches


### PR DESCRIPTION
## Summary
- Add a complete Spanish README translation (`README.es.md`), following the convention from #6.
- Add language navigation links to both READMEs.

Pattern names in the table are localized with Spanish-sounding examples ("Seamos honestos...", "funge como un eje central") rather than literal translations, since the tells sound different in Spanish. Install/use commands stay in English as they are typed verbatim.

## Validation
- Verified heading levels, tables, code blocks, and link targets against `README.md`.
- `git diff --check` clean.

Thanks for building this — I write half my content in Spanish and this skill became my final pass for both languages. Small contribution back.