### PR TITLE
Update plugin workflow actions

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -15,14 +15,14 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Build plugin
         run: python scripts/build_plugin.py
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: no-ai-slop-plugin
           path: dist/no-ai-slop-plugin-*.zip


### PR DESCRIPTION
Updates the official GitHub Actions to their current Node 24-based major versions so plugin builds run without deprecation warnings. YAML and diff checks passed locally.