### PR TITLE
Finalize plugin submission assets

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "no-ai-slop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Remove 20+ AI-slop patterns without flattening the writer's voice.",
   "author": {
     "name": "Peter Yang",
@@ -18,7 +18,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "No AI Slop",
-    "shortDescription": "Remove 20+ AI-slop patterns without flattening your voice.",
+    "shortDescription": "Cut AI slop. Keep your voice.",
     "longDescription": "Edit or audit emails, docs, posts, and other writing for the patterns that make AI-assisted writing feel generic. No AI Slop makes the minimum effective edit, preserves useful details and personality, and explains what changed. Detect mode names the patterns it finds without rewriting or pretending to know whether AI wrote the text. The open-source skill has earned 2.7K+ GitHub stars. Its launch post reached 611K impressions, 10K+ saves, and 13K+ link clicks on X.",
     "developerName": "Peter Yang",
     "category": "Productivity",
@@ -31,11 +31,10 @@
     "privacyPolicyURL": "https://github.com/petergyang/no-ai-slop/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/petergyang/no-ai-slop/blob/main/TERMS.md",
     "defaultPrompt": [
-      "Edit this draft without flattening my voice.",
-      "Flag the AI-slop patterns without rewriting.",
-      "Make this clearer and more direct while preserving my tone."
+      "edit (your writing)",
+      "Is this slop? (a writing excerpt)"
     ],
-    "brandColor": "#F15A29",
+    "brandColor": "#D30800",
     "composerIcon": "./assets/no-ai-slop.svg",
     "logo": "./assets/no-ai-slop.svg"
   }

--- a/assets/no-ai-slop.svg
+++ b/assets/no-ai-slop.svg
@@ -1,8 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
   <title id="title">No AI Slop</title>
-  <desc id="desc">A speech bubble with generic AI sparkles crossed out by an orange slash.</desc>
-  <rect width="512" height="512" rx="112" fill="#FFF9F2"/>
-  <path d="M112 122h288c31 0 56 25 56 56v156c0 31-25 56-56 56H249l-85 67v-67h-52c-31 0-56-25-56-56V178c0-31 25-56 56-56Z" fill="#171717"/>
-  <path d="M205 184l12 31 31 12-31 12-12 31-12-31-31-12 31-12 12-31Zm104 33 15 39 39 15-39 15-15 39-15-39-39-15 39-15 15-39Zm71-61 8 20 20 8-20 8-8 20-8-20-20-8 20-8 8-20Z" fill="#FFF9F2"/>
-  <path d="M105 401 401 105" stroke="#F15A29" stroke-width="52" stroke-linecap="round"/>
+  <desc id="desc">A crisp black shield reading No AI Slop, with AI and Slop crossed out in red.</desc>
+  <defs>
+    <linearGradient id="tile" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#202020"/>
+      <stop offset="1" stop-color="#0D0D0D"/>
+    </linearGradient>
+    <linearGradient id="shield" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#191919"/>
+      <stop offset="1" stop-color="#090909"/>
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="112" fill="url(#tile)" stroke="#343434" stroke-width="10"/>
+  <path d="M256 62 406 116v142c0 94-51 165-150 210C157 423 106 352 106 258V116Z"
+        fill="url(#shield)" stroke="#696969" stroke-width="14" stroke-linejoin="round"/>
+  <path d="M256 82 386 128v130c0 82-43 144-130 186-87-42-130-104-130-186V128Z"
+        fill="none" stroke="#2F2F2F" stroke-width="5" stroke-linejoin="round"/>
+  <text x="256" y="202" text-anchor="middle"
+        font-family="Noto Sans, Arial, sans-serif" font-size="61" font-weight="800"
+        letter-spacing="2" fill="#F8F4EC">NO</text>
+  <text x="256" y="287" text-anchor="middle"
+        font-family="Noto Sans, Arial, sans-serif" font-size="72" font-weight="850"
+        letter-spacing="1" fill="#F8F4EC">AI</text>
+  <text x="256" y="371" text-anchor="middle"
+        font-family="Noto Sans, Arial, sans-serif" font-size="62" font-weight="850"
+        letter-spacing="-2" fill="#F8F4EC">SLOP</text>
+  <path d="M171 267H341M148 350H364"
+        fill="none" stroke="#E43B34" stroke-opacity=".84"
+        stroke-width="18" stroke-linecap="round"/>
 </svg>

--- a/plugin-submission.md
+++ b/plugin-submission.md
@@ -22,9 +22,8 @@ Sources:
 
 ## Starter prompts
 
-1. Edit this draft without flattening my voice.
-2. Flag the AI-slop patterns without rewriting.
-3. Make this clearer and more direct while preserving my tone.
+1. edit (your writing)
+2. Is this slop? (a writing excerpt)
 
 ## Positive test cases
 
@@ -42,4 +41,4 @@ Sources:
 
 ## Release notes
 
-Initial skills-only release. Includes edit and detect modes, voice-preserving instructions, self-checking evals, and no external server or authentication.
+Version 1.0.1 adds the final directory icon and aligns the starter prompts with the edit and detect workflows. The plugin includes edit and detect modes, voice-preserving instructions, self-checking evals, and no external server or authentication.


### PR DESCRIPTION
## What changed

- replace the original sparkle icon with the final No AI Slop shield
- align the plugin starter prompts with the edit and detect entry points
- shorten the directory subtitle and move the brand accent to the approved red
- bump the plugin package to 1.0.1

## Why

The original package metadata and icon no longer matched the submission draft. This keeps the GitHub release, installable package, and OpenAI listing consistent before review.

## Validation

- `scripts/build_plugin.py --check`
- official `plugin-creator` validator
- `git diff --check`
