### PR TITLE
Add Chinese AI slop patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ The patterns it detects include:
 | Synonym cycling | the agent, then the assistant, then the tool |
 | Negative listing | "Not a X. Not a Y. A Z." |
 | Dramatic fragmentation | "That's it. That's the whole thing." |
+| Chinese officialese | "高度重视," "持续推进," "取得积极成效" |
+| Chinese framework padding | "以X为引领、以Y为抓手..." |
+| Chinese public-account hooks | "很多人不知道的是..." |
 
 It also enforces the fundamentals that make writing good: Lead with the point when it helps, use active voice, untangle hard-to-follow sentences, and prefer concrete numbers over abstractions.
+
+It now includes Chinese-language patterns too, especially empty official phrasing, four-character phrase stacks, framework sentences without content, translated-English Chinese, and public-account hook templates.
 
 I use it during the middle 50% of my writing process to improve spelling, grammar, and clarity. I write or dictate the first draft myself, use AI to edit, then do the final line-by-line pass myself. [Read the full 25/50/25 process.](https://creatoreconomy.so/p/use-my-no-ai-slop-skill-to-remove-20-ai-slop-patterns)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: no-ai-slop
-description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, asks whether writing reads as AI, or asks to remove AI flavor from Chinese writing such as official materials, reports, speeches, WeChat posts, social posts, product copy, emails, summaries, and proposals.
 ---
 
 # No AI slop
 
 You are a sharp human editor. Preserve the user's point and personal voice while making the writing clearer and more alive. Remove AI patterns without turning distinctive writing into generic polished prose.
+
+For Chinese drafts, preserve the same voice-first approach. Remove empty fluency, template phrasing, inflated officialese, translated-English stiffness, and generic AI rhythm without flattening the draft into bland formal Chinese.
 
 ## Two jobs
 
@@ -20,6 +22,8 @@ If the user has not provided a draft, ask them to paste it.
 If the audience or format is unclear, ask one question: Who is this for and where will it be published?
 
 If the goal is unclear, ask what the reader should think, feel, or do after reading it.
+
+For Chinese drafts where the audience or format is unclear, ask the same question in Chinese when useful: "这篇是给谁看、发在哪里？"
 
 ## Editing principles
 
@@ -38,6 +42,7 @@ If the goal is unclear, ask what the reader should think, feel, or do after read
 - **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.
 - **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
 - **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
+- **For Chinese, keep useful official language but make the work visible.** Do not blindly delete terms such as "统筹," "机制," "闭环," "协同," "治理," or "赋能" when they are precise in context. Delete or replace them when they hide who does what, to what object, with what result.
 
 ## Words to cut
 
@@ -46,6 +51,10 @@ Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamli
 Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
 
 Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+Chinese often-empty official phrases: 高度重视, 持续推进, 切实加强, 不断深化, 扎实开展, 全面提升, 有效支撑, 有力保障, 取得积极成效, 具有重要意义, 奠定坚实基础. Cut or replace them unless the sentence also names the subject, action, object, and result.
+
+Chinese often-empty transitions and endings: 值得注意的是, 不可忽视的是, 与此同时, 总的来看, 综上所述, 未来将继续, 可以看出, 需要指出的是. Cut them when they delay the point. Replace them only when a real logical relation needs to be named: cause, contrast, condition, result, risk, or next step.
 
 ## Patterns to cut
 
@@ -83,11 +92,30 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
 
+**Chinese four-character phrase stacks.** "统筹推进、协同联动、精准施策、提质增效、落地见效" sounds like planning theater when the sentence never says what changed. Keep the one or two terms that carry meaning. Convert the rest into concrete actions or delete them.
+
+**Chinese framework without content.** "以X为引领、以Y为抓手、以Z为保障，推动A、B、C全面提升" is not specific unless the draft names the mechanism, owner, workflow, deliverable, or next action. Keep the framework only when the format requires it, then follow it with concrete detail.
+
+**Chinese fake specificity.** "构建完善体系," "形成闭环机制," "打造一体化平台," "建立长效机制," and "实现全流程管理" sound specific while hiding the parts, steps, metrics, or responsibilities. Name the actual system parts or flag that detail is missing.
+
+**Chinese inflated significance.** "标志着重要突破," "具有里程碑意义," "开启新篇章," "注入强劲动能," and "彰显了决心" inflate the fact. State the fact and let the reader judge. Keep significance only when the draft proves why it matters.
+
+**Chinese vague attribution.** "业内普遍认为," "相关研究表明," "有观点指出," "实践证明," and "专家表示" need named sources. If the user has no source, cut the claim or ask for one.
+
+**Translated-English Chinese.** "作为一个...," "对于...而言," "在...方面," "通过...的方式来...," and "它能够帮助用户去实现..." often read like English wearing Chinese clothes. Rewrite as direct Chinese with subject, action, object, and result.
+
+**Chinese noun pileups.** "能力建设水平提升工作," "平台化支撑能力体系," and "全链路质量治理机制建设" bury verbs inside nouns. Unpack the chain into a sentence. Keep technical terms only when the target reader expects them.
+
+**Chinese public-account hooks.** "很多人不知道的是," "真正厉害的人都懂," "看完这篇你就明白了," "这才是关键," and "答案可能和你想的不一样" promise insight before delivering it. Cut the setup and make the claim stand on its own unless the hook is clearly part of the writer's voice.
+
+**Forced positivity.** Do not turn risks, limits, or tradeoffs into "机遇," "新空间," or "新动能" without analysis. Name the tradeoff plainly. Human writing can be uncertain, critical, or unresolved.
+
 ## Workflow
 
 1. Read the full draft before editing.
 2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
-3. For a detect request, return the findings report described in Two jobs and stop.
-4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
-5. If any check fails, fix the draft and run the checks again.
-6. Output the full edited draft and a short **What changed** section.
+3. For Chinese drafts, identify the register before editing: formal material, public writing, or spoken draft. Keep necessary formality in formal material, keep energy in public writing, and keep speakable rhythm in spoken drafts.
+4. For a detect request, return the findings report described in Two jobs and stop.
+5. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
+6. If any check fails, fix the draft and run the checks again.
+7. Output the full edited draft and a short **What changed** section.

--- a/eval.md
+++ b/eval.md
@@ -16,6 +16,7 @@ For detect requests, make sure the response names each pattern found with a quot
 8. Does the draft use active voice with human subjects where possible?
 9. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
 10. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
+11. For Chinese drafts, does the edit keep useful formality without hiding actions behind slogans?
 
 ## Words to cut
 
@@ -31,6 +32,13 @@ For detect requests, make sure the response names each pattern found with a quot
 6. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
 7. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
 8. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+9. For Chinese drafts, are empty official phrases removed or backed by concrete subjects, actions, objects, and results?
+10. For Chinese drafts, are four-character phrase stacks reduced to terms that carry meaning?
+11. For Chinese drafts, are framework-without-content sentences either made concrete or left with a clear note that detail is missing?
+12. For Chinese drafts, are inflated significance claims replaced by facts unless the draft proves the significance?
+13. For Chinese drafts, are unsupported vague attributions cut, named, or flagged?
+14. For Chinese drafts, are generic transitions and summary padding removed where they delay the point?
+15. For Chinese drafts, are translated-English structures and noun pileups rewritten into natural Chinese where possible?
 
 ## Final read
 
@@ -38,5 +46,6 @@ For detect requests, make sure the response names each pattern found with a quot
 2. Does the draft avoid robotic symmetry, repeated sentence shapes, and stacked punchy fragments?
 3. Would the writer recognize the edited draft as their own voice?
 4. Would the edited draft sound natural if read to a sharp colleague?
-5. Does the final output include the full edited draft and a short **What changed** section?
-6. For detect requests, does the response name each pattern with a quoted line and a short fix, without rewriting, scoring, or claiming AI authorship?
+5. For Chinese drafts, would the edited draft sound natural to the target reader in its register: formal material, public writing, or spoken draft?
+6. Does the final output include the full edited draft and a short **What changed** section?
+7. For detect requests, does the response name each pattern with a quoted line and a short fix, without rewriting, scoring, or claiming AI authorship?


### PR DESCRIPTION
## Summary

Adds Chinese-language AI-slop coverage to the existing skill while keeping the same voice-preserving editing workflow.

## What changed

- Extends the skill description and workflow for Chinese drafts.
- Adds Chinese-specific patterns for empty officialese, four-character phrase stacks, framework padding, fake specificity, inflated significance, vague attribution, translated-English Chinese, noun pileups, public-account hooks, and forced positivity.
- Updates eval checks so Chinese edits preserve register while removing template phrasing.
- Documents the new Chinese coverage in the README.

## Validation

- Ran a read-only source validation for required package files and SKILL.md frontmatter.
- Ran git diff --check.

I did not run scripts/build_plugin.py --check because it creates and removes the dist directory; the source/package contract was checked without touching generated output.