### PR TITLE
fix: correct pattern count (17, not 20+) and voice signal range

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "no-ai-slop",
   "version": "1.0.4",
-  "description": "Remove 20+ patterns of AI slop from any piece of writing without flattening your personal voice.",
+  "description": "Remove 17 patterns of AI slop from any piece of writing without flattening your personal voice.",
   "author": {
     "name": "Peter Yang",
     "url": "https://creatoreconomy.so"
@@ -19,7 +19,7 @@
   "interface": {
     "displayName": "No AI Slop",
     "shortDescription": "Cut AI slop. Keep your voice.",
-    "longDescription": "This plugin removes 20+ patterns of AI slop from any piece of writing without flattening your personal voice. It can also detect slop without guessing whether AI wrote the text.\n\nMore than 2,700 people have starred it on [GitHub](https://github.com/petergyang/no-ai-slop). The [launch post on X](https://x.com/petergyang/status/2079943830024188105) reached 611K impressions, 10K+ saves, and 13K+ link clicks.",
+    "longDescription": "This plugin removes 17 patterns of AI slop from any piece of writing without flattening your personal voice. It can also detect slop without guessing whether AI wrote the text.\n\nMore than 2,700 people have starred it on [GitHub](https://github.com/petergyang/no-ai-slop). The [launch post on X](https://x.com/petergyang/status/2079943830024188105) reached 611K impressions, 10K+ saves, and 13K+ link clicks.",
     "developerName": "Peter Yang",
     "category": "Productivity",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # No AI slop
 
-This open-source skill removes 20+ patterns of AI slop from your writing without flattening your personal voice. It can also detect slop without guessing whether AI wrote the text.
+This open-source skill removes 17 patterns of AI slop from your writing without flattening your personal voice. It can also detect slop without guessing whether AI wrote the text.
 
 More than 2,700 people have starred it on [GitHub](https://github.com/petergyang/no-ai-slop). The [launch post on X](https://x.com/petergyang/status/2079943830024188105) reached 611K impressions, 10K+ saves, and 13K+ link clicks.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -86,7 +86,7 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 ## Workflow
 
 1. Read the full draft before editing.
-2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
+2. Identify the core point and 3-6 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
 3. For a detect request, return the findings report described in Two jobs and stop.
 4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.
 5. If any check fails, fix the draft and run the checks again.

--- a/plugin-submission.md
+++ b/plugin-submission.md
@@ -2,7 +2,7 @@
 
 ## Positioning
 
-No AI Slop removes 20+ patterns that make AI-assisted writing sound generic without flattening the writer's voice.
+No AI Slop removes 17 patterns that make AI-assisted writing sound generic without flattening the writer's voice.
 
 Peter uses it during the middle 50% of his writing process to improve spelling, grammar, and clarity. He writes the first draft himself and does the final line-by-line pass himself.
 


### PR DESCRIPTION
## Summary

- Updated pattern count from "20+" to "17" across README, plugin.json, and plugin-submission.md to match the actual number of patterns defined in SKILL.md
- Fixed voice signal range from "3-5" to "3-6" in SKILL.md to match the 6 examples listed

## Changes

**Pattern count (4 locations):**
- `README.md` line 3
- `plugin-submission.md` line 5
- `.codex-plugin/plugin.json` lines 4 and 22

SKILL.md defines exactly 17 distinct patterns: Binary contrasts, Throat-clearing openers, Faux-insight setups, Colon reveals, Superficial analysis, Importance puffery, Weasel attribution, Fake-strong verbs, Synonym cycling, Negative listing, Dramatic fragmentation, Robotic rhythm, Rhetorical setups, Fake-profound kickers, Summary-recap endings, Formatting slop, Em dashes.

**Voice signal range (1 location):**
- `SKILL.md` line 89: "3-5 voice signals" → "3-6 voice signals"

The instruction lists 6 examples (vocabulary, cadence, bluntness, humor, uncertainty, digressions) but the range said "3-5".

## Test plan

- [x] Manually counted all 17 patterns in SKILL.md
- [x] Verified all 6 voice signal examples
- [x] No external URLs modified