### PR TITLE
fix: scope plugin check cleanup

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -114,7 +114,12 @@ def main() -> None:
     validate_build(plugin_root, archive)
     print(f"Built {archive.relative_to(ROOT)}")
     if args.check:
-        shutil.rmtree(DIST)
+        shutil.rmtree(plugin_root)
+        archive.unlink()
+        try:
+            DIST.rmdir()
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep --check cleanup scoped to the plugin package files generated by scripts/build_plugin.py
- leave unrelated files in dist/ intact, and remove dist/ only when it is empty

## Validation
- python3 scripts/build_plugin.py
- python3 scripts/build_plugin.py --check
- verified a pre-existing dist/keep.txt survives --check cleanup