### PR TITLE
Add the portability test for generic filler

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -33,6 +33,7 @@ If the goal is unclear, ask what the reader should think, feel, or do after read
 - **Make every sentence earn its place.** Cut empty qualifiers and throat-clearing. Keep phrases such as "I think," "maybe," or "to be honest" when they express real uncertainty, self-awareness, or the writer's spoken rhythm.
 - **Untangle sentences without flattening the cadence.** Split sentences and paragraphs when they are genuinely hard to follow. Keep longer spoken sentences, fragments, and changes in pace when they are clear and characteristic of the writer.
 - **Be concrete and specific.** Abstraction is where writing goes to die. "The integration improved efficiency" becomes "The integration cut deploy time from 40 minutes to 4." Names, numbers, dates, mechanisms, and examples beat abstractions.
+- **Use the portability test.** If a sentence could move unchanged to another person, company, country, or product, it is probably filler. Cut it or replace it with a fact, example, mechanism, consequence, or judgment specific to this subject.
 - **Protect the specific fact.** Don't smooth a useful detail into generic importance. "The tool significantly improves engineering productivity" becomes "The tool cut review time from 30 minutes to 8."
 - **Make verbs do the work.** Replace weak verb phrases with direct verbs. "Made a decision" becomes "decided." "Has the ability to" becomes "can."
 - **Know the job.** Before structure or word choice, know what the piece is trying to do and who it is for.

--- a/eval.md
+++ b/eval.md
@@ -13,9 +13,10 @@ For detect requests, make sure the response names each pattern found with a quot
 5. Does the draft lead with what the reader needs while keeping personal setup that adds context, tension, or character?
 6. Are points front-loaded where that improves clarity without forcing every unit into the same structure?
 7. Do sentences earn their place, with concrete facts, protected details, and direct verbs where the draft supports them?
-8. Does the draft use active voice with human subjects where possible?
-9. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
-10. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
+8. Does every generic sentence pass the portability test, or was it cut or made specific to this subject?
+9. Does the draft use active voice with human subjects where possible?
+10. Does the edit keep useful edge and preserve structure unless the structure was hurting the piece?
+11. Are genuinely tangled sentences fixed while clear spoken cadence, fragments, and changes in pace remain intact?
 
 ## Words to cut
 


### PR DESCRIPTION
## Summary

Adds one editing principle: if a sentence could move unchanged to another person, company, country, or product, it is probably filler. The fix is to cut it or make it specific with a fact, example, mechanism, consequence, or judgment.

Adds the matching self-check to `eval.md`.

This is intentionally narrow. It does not add another pattern catalog or change either edit/detect workflow.

## Verification

- `python3 scripts/build_plugin.py --check`
- `git diff --check`