### PR TITLE
Add a fact-binding rule for technical drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The patterns it detects include:
 
 It also enforces the fundamentals that make writing good: Lead with the point when it helps, use active voice, untangle hard-to-follow sentences, and prefer concrete numbers over abstractions.
 
+For drafts containing numbers, units, named entities or attributions, a separate fact-binding rule switches on. Compression is where factual links break, and in technical writing a broken link is invisible: two correct paragraphs about different subjects get merged, and a measurement belonging to one now explains the other. Nothing is misspelled and no number changed. The rule freezes numbers, units, names and attributions, forbids restructuring across a subject boundary without re-checking each fact against the original, protects qualifiers that state a basis or condition rather than reluctance, and requires the What changed section to list every touched sentence that carried a number or a name.
+
 I use it during the middle 50% of my writing process to improve spelling, grammar, and clarity. I write or dictate the first draft myself, use AI to edit, then do the final line-by-line pass myself. [Read the full 25/50/25 process.](https://creatoreconomy.so/p/use-my-no-ai-slop-skill-to-remove-20-ai-slop-patterns)
 
 ## Install

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,6 +39,45 @@ If the goal is unclear, ask what the reader should think, feel, or do after read
 - **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
 - **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
 
+## Technical content: the fact-binding rule
+
+Switch this on whenever the draft contains numbers, units, named entities (products,
+systems, materials, versions, people), attributions, or causal claims. Most of the rules
+above optimise for compression. **Compression is where factual links break.** In technical
+writing a broken link is invisible, because the prose reads better while saying something
+false.
+
+The failure looks like this. Two adjacent paragraphs each describe a different subject and
+each is correct. Tightening merges them. The result is one fluent paragraph in which a
+measurement belonging to subject A now explains subject B. Nothing is misspelled, no number
+changed, and the claim is fabricated. This has actually happened and it survived several
+re-readings by the person who wrote it.
+
+**Rules, in force whenever the switch is on:**
+
+- **Never merge, split or reorder across a subject boundary without re-checking each fact
+  against the original.** A subject boundary is any point where the thing being described
+  changes, such as a different material, dataset, tool, version, run, or person.
+- **Numbers, units, entity names and attributions are frozen.** They survive byte-identical
+  unless the writer asked for a change. Rounding a figure, dropping a unit, or replacing a
+  specific name with a general one is a content change, not a style change.
+- **After editing, verify subject-fact binding.** For every claim carrying a number or a
+  name, ask: is it still attached to the same subject as in the original? Do this as a
+  separate pass, reading the edited draft against the original, not from memory of it.
+- **Do not remove a hedge that carries technical meaning.** "Within this model", "on the
+  solid basis", "computed rather than measured", "at one bar" look like throat-clearing and
+  are load-bearing. If a qualifier states a basis, a condition, or the limits of a method,
+  it stays. Cut hedges that express only reluctance, never hedges that state scope.
+- **Do not let the ban on synonym cycling flatten two different things into one word.** If
+  the draft uses two terms because they denote two quantities, keep both.
+- **If tightening would require you to know whether something is true, stop and ask.** The
+  editor's job is prose. Deciding that two facts can be joined is a technical judgement.
+
+**In the What changed section, list separately every sentence you touched that contained a
+number, a unit, a named entity or an attribution.** The writer can then re-verify exactly
+those and nothing else. Without that list they have to re-verify the whole draft, which
+means they will not.
+
 ## Words to cut
 
 Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.

--- a/eval.md
+++ b/eval.md
@@ -32,6 +32,17 @@ For detect requests, make sure the response names each pattern found with a quot
 7. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
 8. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
 
+## Technical content
+
+Answer these only if the draft contains numbers, units, named entities, attributions, or causal claims. If it does, a fail here outranks every other check on this page.
+
+1. Is every number, unit, entity name and attribution byte-identical to the original, unless the writer asked for a change?
+2. Was any content merged, split or reordered across a subject boundary, meaning a change of material, dataset, tool, version, run or person? If so, was each affected fact re-checked against the original rather than from memory?
+3. For every claim carrying a number or a name, is it still attached to the same subject it was attached to in the original?
+4. Were qualifiers that state a basis, a condition, or the limits of a method left intact, rather than cut as throat-clearing?
+5. Where the draft used two different terms for two different quantities, were both kept rather than unified?
+6. Does the **What changed** section list separately every touched sentence that contained a number, a unit, a named entity or an attribution?
+
 ## Final read
 
 1. Was the edit checked directly against this file without requiring separate editor and evaluator agents?


### PR DESCRIPTION
The skill optimises for compression, and compression is where factual links break. On a draft containing numbers and named entities that failure is invisible: two adjacent paragraphs, each correct and each about a different subject, get merged during tightening, and a measurement belonging to one now explains the other. Nothing is misspelled and no number changed.

This happened to me on a technical email. The merged paragraph attributed a solidification result from one alloy to a solubility figure from a different alloy. It read better than the original and survived several re-readings before an outside reviewer caught it.

Nothing in the skill prevented it. "Keep the user's meaning" guards against adding claims, not against rebinding existing ones. "Protect the specific fact" guards against smoothing a detail into generic language, not against moving it to the wrong subject. And "Keep structure unless it's hurting the piece" sanctions reorganising with only a requirement to say why, not to re-verify. eval.md ran 24 checks and none asked whether the facts survived.

SKILL.md gains a section that switches on for drafts with numbers, units, named entities, attributions or causal claims:

- numbers, units, names and attributions are frozen
- no merging, splitting or reordering across a subject boundary without re-checking each fact against the original
- subject-fact binding verified as a separate pass, read against the original rather than from memory
- qualifiers that state a basis or a condition are protected; the ones that express only reluctance are still fair game
- the synonym-cycling ban must not collapse two terms that denote two different quantities
- if tightening requires knowing whether something is true, stop and ask

It also requires the What changed section to list separately every touched sentence carrying a number or a name, so the writer can re-verify exactly those. Without that list they have to re-check the whole draft, which means they will not.

eval.md gains six matching checks, gated on technical content, ranked above every other check on the page so voice never wins over a broken fact.