### PR TITLE
Agent/french academic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,6 @@ The repository also contains a skills-only plugin package for ChatGPT and Codex.
 
 ## Use
 
-### French academic and research writing
-
-The skill also edits and audits French academic prose while preserving citations, statistics, technical terms, warranted uncertainty, and the distinction between association and causation.
-
-```text
-/no-ai-slop
-
-Révise ce passage pour un article scientifique en français sans modifier le degré de certitude ni les résultats.
-
-[votre texte]
-```
-
-It detects the language automatically and does not translate unless asked.
-
 **1. Edit a draft.** Paste it and invoke the skill:
 
 ```
@@ -69,6 +55,18 @@ You get back the edited draft plus a short What changed section. The skill makes
 ```
 
 You get every pattern it found each with the quoted line.
+
+### French academic and research writing
+
+The skill can also edit or audit French academic prose. It preserves citations, statistics, technical terms, and the degree of certainty, and it does not translate unless asked.
+
+```text
+/no-ai-slop
+
+Révise ce passage pour un article scientifique en français sans modifier le degré de certitude ni les résultats.
+
+[votre texte]
+```
 
 ## Files
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ The repository also contains a skills-only plugin package for ChatGPT and Codex.
 
 ## Use
 
+### French academic and research writing
+
+The skill also edits and audits French academic prose while preserving citations, statistics, technical terms, warranted uncertainty, and the distinction between association and causation.
+
+```text
+/no-ai-slop
+
+Révise ce passage pour un article scientifique en français sans modifier le degré de certitude ni les résultats.
+
+[votre texte]
+```
+
+It detects the language automatically and does not translate unless asked.
+
 **1. Edit a draft.** Paste it and invoke the skill:
 
 ```
@@ -62,6 +76,9 @@ You get every pattern it found each with the quoted line.
 2. `eval.md`: Pass/fail checks the skill runs on its own edits.
 3. `.codex-plugin/plugin.json`: Metadata for the ChatGPT and Codex plugin.
 4. `scripts/build_plugin.py`: Builds and validates the plugin ZIP from the canonical skill files.
+5. `references/english.md`: English-specific editing patterns.
+6. `references/french-academic.md`: French academic and research guidance.
+7. `tests/french-academic-cases.md`: Behavioral regression fixtures.
 
 ## Who made this
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-ai-slop
-description: Edit drafts into sharper, more human writing while preserving the writer's personal voice, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
+description: Edit English drafts and French academic and research writing into sharper, more human prose while preserving the writer's voice, evidence, and degree of certainty, or detect AI-slop patterns without rewriting. Use when the user wants a draft clearer, more direct, more opinionated, or less AI-sounding, or asks whether writing reads as AI.
 ---
 
 # No AI slop
@@ -39,53 +39,20 @@ If the goal is unclear, ask what the reader should think, feel, or do after read
 - **Preserve useful edge and character.** Keep strong opinions, blunt language, humor, profanity, self-interruptions, and honest admissions when they belong to the writer. Don't replace them with safer or more professional wording.
 - **Keep structure unless it's hurting the piece.** Preserve the writer's progression and detours when they carry personality. If you reorganize, say why in the What changed section.
 
-## Words to cut
+## Language routing
 
-Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+Identify the language of each passage before editing or detecting patterns.
 
-Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+- English: read `references/english.md`.
+- French academic or research prose: read `references/french-academic.md`.
+- Mixed French-English drafts: read both references and apply each only to its matching passages.
+- Other languages: apply the core principles conservatively and tell the user that no language-specific reference is available.
 
-Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
-
-## Patterns to cut
-
-**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
-
-**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
-
-**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
-
-**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
-
-**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
-
-**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
-
-**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
-
-**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
-
-**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
-
-**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
-
-**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
-
-**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
-
-**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
-
-**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
-
-**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
-
-**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
-
-**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.
+Do not translate unless the user explicitly asks. Write the response in the draft's primary language unless the user requests another language.
 
 ## Workflow
 
-1. Read the full draft before editing.
+1. Read the full draft, identify the language of each passage, and load the matching language reference before editing.
 2. Identify the core point and 3-5 voice signals to preserve, such as vocabulary, cadence, bluntness, humor, uncertainty, or digressions. Keep this note internal. If you cannot identify the core point, ask the user.
 3. For a detect request, return the findings report described in Two jobs and stop.
 4. For an edit, make the minimum effective changes, then check the edited draft against `eval.md` yourself.

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "/no-ai-slop"
-  short_description: "Remove AI slop while preserving the writer's personal voice."
-  default_prompt: "Use $no-ai-slop to remove AI patterns from this draft while preserving my personal voice."
+  short_description: "Remove AI slop from English or French academic prose while preserving the writer's voice."
+  default_prompt: "Use $no-ai-slop to remove AI patterns from this English or French academic draft while preserving my voice, evidence, and degree of certainty."

--- a/eval.md
+++ b/eval.md
@@ -40,3 +40,12 @@ For detect requests, make sure the response names each pattern found with a quot
 4. Would the edited draft sound natural if read to a sharp colleague?
 5. Does the final output include the full edited draft and a short **What changed** section?
 6. For detect requests, does the response name each pattern with a quoted line and a short fix, without rewriting, scoring, or claiming AI authorship?
+
+## French academic and research writing
+
+1. If the draft is French academic or research prose, was `references/french-academic.md` applied?
+2. Are citations, numbers, units, estimates, intervals, p-values, acronyms, method names, and technical terms unchanged unless correction was explicitly requested?
+3. Does the edit preserve warranted uncertainty, study-design limitations, and the distinction between association and causation?
+4. Did the edit avoid inventing sources, mechanisms, populations, explanations, or findings?
+5. Were French stock phrases, vague abstractions, nominalisations, unsupported attribution, and literal English calques fixed only where they weakened the text?
+6. Does French output use a short **Modifications apportées** section and otherwise follow the user's requested language?

--- a/references/english.md
+++ b/references/english.md
@@ -1,0 +1,47 @@
+# English editing reference
+
+Use these rules for English passages. Apply them with the voice-preservation and minimum-edit principles in `SKILL.md`.
+
+## Words to cut
+
+Banned outright: delve, foster, leverage, utilize, facilitate, empower, streamline, robust, cutting-edge, paradigm shift, game changer, this is huge, this changes everything, tapestry, realm, beacon, multifaceted, meticulous, intricate, paramount, transformative, elevate, embark, supercharge, harness, ever-evolving.
+
+Often-empty adverbs: just, literally, honestly, simply, actually, truly, fundamentally, importantly, crucially, inherently, inevitably. Cut them when they add nothing. Keep them when they carry emphasis, uncertainty, contrast, or the writer's natural spoken rhythm.
+
+Often-empty phrases: it's worth noting, it's important to note, at the end of the day, when it comes to, at its core, in today's world, in the age of, in the world of, the reality is, the truth is, in terms of, with regard to, in order to, going forward, in this article, let's dive in. Cut them when they delay the point. Keep an occasional phrase when it is part of the writer's recognizable voice and the sentence still earns its place.
+
+## Patterns to cut
+
+**Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
+
+**Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
+
+**Faux-insight setups.** "This is the part most people skip," "What most people get wrong," "Here's what nobody tells you," "The part everyone misses." These flatter the writer as the lone expert. Cut the setup and make the claim stand on its own. "The part everyone misses: distribution is the real moat" becomes "Distribution is the moat."
+
+**Colon reveals.** A noun phrase, a colon, then a lowercase dramatic reveal: "The detail that makes it work: a separate agent grades it." "The best part: it learns." Rewrite as a plain sentence ("A separate agent does the grading, which is what makes it work"). Use colons for lists, labels, and quotes, not fake drama. Prefer sentence case after a colon unless grammar, a proper noun, a title, or code requires otherwise.
+
+**Superficial analysis.** Cut trailing `-ing` clauses that pretend to explain meaning: "highlighting," "underscoring," "reflecting," "showcasing." "The launch adds file search, highlighting the team's commitment to better workflows" becomes "The launch adds file search, so users can find old drafts without leaving the editor."
+
+**Importance puffery.** "Stands as a testament," "marks a pivotal moment," "plays a vital role," "solidifies its position," "underscores its significance." State the fact and let the reader judge whether it matters. "The launch marks a pivotal moment for the company" becomes "The launch is the company's first paid product."
+
+**Weasel attribution.** "Experts agree," "industry reports suggest," "many argue," "widely regarded as," "studies show." Name the source or cut the claim. If the user has no source, ask instead of inventing one.
+
+**Fake-strong verbs.** Prefer "is" and "has" when they are clearer. "The app serves as a centralized hub for sponsor management" becomes "The app tracks sponsors, drafts, due dates, and approvals in one place."
+
+**Synonym cycling.** If the clear word is right, repeat it. Don't rotate terms for style. "The agent reviews the draft. The assistant scores the piece. The tool suggests fixes" becomes "The agent reviews the draft, scores it, and suggests fixes."
+
+**Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
+
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+
+**Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
+
+**Rhetorical setups.** "What if I told you...", "Think about it:", "Plot twist:", and self-answered "Question? Answer." pairs. Drop them and make the point.
+
+**Fake-profound kickers.** Cut the final "deep" line when it turns the point into a cute metaphor, aphorism, or mic-drop sentence. Do not rewrite it into a better metaphor. Do not preserve the rhythm. Delete it, then end on the clearest concrete sentence already in the draft. If the ending needs more closure, add a plain takeaway or next action.
+
+**Summary-recap endings.** "In conclusion," "Ultimately," "Overall," or a final paragraph that restates the piece. The reader was just there. End on the last concrete point, takeaway, or next action instead.
+
+**Formatting slop.** Emoji in headings, bold sprinkled mid-sentence for emphasis, bullet lists where two sentences of prose would read better, and headers over two-sentence sections. Format should follow the content, not decorate it.
+
+**Em dashes.** Do not use them as a default rhythm crutch. In short copy, use none. In longer drafts, 1-2 are fine if they clearly beat commas, periods, or parentheses. Remove clusters and decorative dashes.

--- a/references/french-academic.md
+++ b/references/french-academic.md
@@ -1,0 +1,52 @@
+# Référence pour le français scientifique
+
+Utiliser ces règles pour les articles, rapports, thèses et communications scientifiques en français. Préserver le sens, le degré de certitude, la terminologie disciplinaire et la voix de l'auteur. Corriger le minimum nécessaire.
+
+## Intégrité scientifique
+
+- Conserver exactement les citations, nombres, unités, estimations, intervalles de confiance, valeurs p, acronymes et noms de méthodes.
+- Ne jamais inventer une source, un mécanisme, une population, une explication ou un résultat.
+- Ne pas transformer une association en effet ou en causalité.
+- Conserver les modalisateurs justifiés par les données ou le devis : *peut*, *pourrait*, *semble*, *suggère*, *compatible avec*.
+- Conserver les limites méthodologiques et les distinctions entre résultat, interprétation et hypothèse.
+
+## Formules souvent creuses
+
+Traiter comme des signaux à vérifier, pas comme des interdictions automatiques : *il convient de noter*, *force est de constater*, *dans un contexte en constante évolution*, *au cœur de*, *revêt une importance particulière*, *joue un rôle crucial*, *met en lumière*, *souligne l'importance*, *constitue un levier*, *s'inscrit dans une démarche*, *approche globale et intégrée*.
+
+Supprimer la formule lorsque la proposition restante porte le sens. La conserver seulement si elle exprime une distinction méthodologique réelle.
+
+## Abstractions et nominalisations
+
+Les mots *enjeu*, *dynamique*, *levier*, *démarche*, *problématique*, *optimisation* et *valorisation* doivent désigner un objet précis. Sinon, nommer l'exposition, le résultat, la population, la méthode ou l'action réellement décrite.
+
+Préférer un verbe précis à une chaîne nominale : *procéder à une analyse de* devient *analyser*; *effectuer une comparaison de* devient *comparer*. Ne pas simplifier un terme technique consacré.
+
+## Attribution vague
+
+Signaler *la littérature montre*, *les études prouvent*, *il est largement reconnu* et *de nombreux auteurs soulignent* lorsque la source n'est pas nommée. Demander une citation ou réduire la portée de l'énoncé; ne jamais fabriquer une référence.
+
+## Structures artificielles
+
+- Contraste binaire : *il ne s'agit pas seulement de X, mais de Y*. Énoncer directement la relation utile.
+- Conclusion récapitulative : *en conclusion*, *en somme*, *au final* suivis d'une répétition. Terminer sur la dernière implication concrète.
+- Rythme mécanique : paragraphes de même forme, transitions répétées, séries de trois adjectifs abstraits. Varier seulement si la lecture l'exige.
+- Traduction littérale : éviter *adresser un problème*, *évidence* au sens de preuve, *impacter*, et *faire sens* lorsque *traiter*, *données probantes*, *influer sur* ou *avoir du sens* expriment l'idée.
+
+## Conventions françaises
+
+- Employer les espaces typographiques françaises avant `:`, `;`, `?` et `!` sans altérer le contenu des citations ou du code.
+- Employer les guillemets français lorsque le texte en utilise, mais ne pas reformater une bibliographie entière sans demande.
+- Respecter les conventions du domaine pour les acronymes, unités, décimales et majuscules.
+
+## Sortie
+
+Pour une révision en français, rendre le texte complet puis une courte section **Modifications apportées**. Pour une détection, nommer chaque motif, citer le passage et proposer une correction brève sans réécrire le texte ni attribuer une probabilité d'origine IA.
+
+## Exemple
+
+Avant : « Dans un contexte en constante évolution, il convient de noter que la couverture vaccinale constitue un levier essentiel pour optimiser la prévention. »
+
+Après : « La couverture vaccinale contribue à la prévention. »
+
+La révision supprime les formules creuses sans inventer de population, de mécanisme ni d'estimation.

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -45,7 +45,13 @@ def validate_source(manifest: dict) -> None:
     if len(prompts) > 3 or any(len(prompt) > 128 for prompt in prompts):
         raise SystemExit("Starter prompts must contain at most three entries of 128 characters or fewer")
 
-    for source in (ROOT / "SKILL.md", ROOT / "eval.md", ROOT / "assets" / "no-ai-slop.png"):
+    for source in (
+        ROOT / "SKILL.md",
+        ROOT / "eval.md",
+        ROOT / "references" / "english.md",
+        ROOT / "references" / "french-academic.md",
+        ROOT / "assets" / "no-ai-slop.png",
+    ):
         if not source.is_file():
             raise SystemExit(f"Missing package source: {source.relative_to(ROOT)}")
 
@@ -58,11 +64,16 @@ def build_plugin(manifest: dict) -> tuple[Path, Path]:
     skill_root = plugin_root / "skills" / "no-ai-slop"
     (plugin_root / ".codex-plugin").mkdir(parents=True)
     (plugin_root / "assets").mkdir(parents=True)
-    skill_root.mkdir(parents=True)
+    (skill_root / "references").mkdir(parents=True)
 
     shutil.copy2(MANIFEST, plugin_root / ".codex-plugin" / "plugin.json")
     shutil.copy2(ROOT / "SKILL.md", skill_root / "SKILL.md")
     shutil.copy2(ROOT / "eval.md", skill_root / "eval.md")
+    shutil.copy2(ROOT / "references" / "english.md", skill_root / "references" / "english.md")
+    shutil.copy2(
+        ROOT / "references" / "french-academic.md",
+        skill_root / "references" / "french-academic.md",
+    )
     shutil.copy2(ROOT / "assets" / "no-ai-slop.png", plugin_root / "assets" / "no-ai-slop.png")
     shutil.copy2(ROOT / "LICENSE", plugin_root / "LICENSE")
     shutil.copy2(ROOT / "PRIVACY.md", plugin_root / "PRIVACY.md")
@@ -84,12 +95,14 @@ def validate_build(plugin_root: Path, archive: Path) -> None:
         "assets/no-ai-slop.png",
         "skills/no-ai-slop/SKILL.md",
         "skills/no-ai-slop/eval.md",
+        "skills/no-ai-slop/references/english.md",
+        "skills/no-ai-slop/references/french-academic.md",
         "LICENSE",
         "PRIVACY.md",
         "TERMS.md",
     }
     actual = {
-        str(path.relative_to(plugin_root))
+        path.relative_to(plugin_root).as_posix()
         for path in plugin_root.rglob("*")
         if path.is_file()
     }
@@ -102,6 +115,11 @@ def validate_build(plugin_root: Path, archive: Path) -> None:
         raise SystemExit("Packaged SKILL.md does not match the canonical file")
     if packaged_eval.read_bytes() != (ROOT / "eval.md").read_bytes():
         raise SystemExit("Packaged eval.md does not match the canonical file")
+    for reference_name in ("english.md", "french-academic.md"):
+        packaged_reference = plugin_root / "skills" / "no-ai-slop" / "references" / reference_name
+        canonical_reference = ROOT / "references" / reference_name
+        if packaged_reference.read_bytes() != canonical_reference.read_bytes():
+            raise SystemExit(f"Packaged {reference_name} does not match the canonical file")
     if not zipfile.is_zipfile(archive):
         raise SystemExit("Plugin archive is not a valid ZIP file")
 

--- a/tests/french-academic-cases.md
+++ b/tests/french-academic-cases.md
@@ -1,0 +1,51 @@
+# French academic evaluation cases
+
+Run each case in a fresh context with the source passage unchanged.
+
+## FR-EDIT-01: Formulaic academic prose
+
+Prompt: `/no-ai-slop Révise ce paragraphe pour un article scientifique en français.`
+
+> Dans un contexte en constante évolution, il convient de noter que la vaccination constitue un levier essentiel permettant d'optimiser la prévention. Cette dynamique met en lumière l'importance cruciale d'une démarche globale et intégrée.
+
+Pass: removes formulaic setup and inflated abstractions; invents no mechanism, population, result, or citation; returns French prose plus `Modifications apportées`.
+
+## FR-INTEGRITY-02: Association is not causation
+
+Prompt: `/no-ai-slop Révise ce résultat sans modifier son degré de certitude.`
+
+> Dans cette étude transversale, l'exposition était associée à une probabilité plus élevée de vaccination (OR ajusté : 1,42 ; IC à 95 % : 1,08–1,87). Ces résultats pourraient refléter des différences d'accès aux services, mais le devis ne permet pas d'établir une relation causale.
+
+Pass: preserves the study design, estimate, interval, `pourraient`, and causal limitation; does not turn association into effect or causation.
+
+## FR-CITATIONS-03: Citations and terminology
+
+Prompt: `/no-ai-slop Révise au minimum ce passage de méthodes.`
+
+> L'hésitation vaccinale a été définie selon le cadre du SAGE Working Group [12]. Les rapports de prévalence ajustés (RPa) et leurs intervalles de confiance à 95 % ont été estimés au moyen d'une régression de Poisson à variance robuste.
+
+Pass: retains `SAGE Working Group [12]`, `RPa`, `95 %`, and the named model; makes few or no edits.
+
+## FR-HUMAN-04: Strong prose remains intact
+
+Prompt: `/no-ai-slop Révise seulement ce qui sonne artificiel.`
+
+> Nos données ne disent pas pourquoi certaines personnes ont refusé le vaccin. Elles montrent toutefois que le refus était plus fréquent loin des centres de santé, y compris après ajustement sur l'âge et le niveau d'instruction.
+
+Pass: leaves both sentences substantially intact and adds no explanation.
+
+## FR-DETECT-05: Detection only
+
+Prompt: `/no-ai-slop Détecte les formulations artificielles sans réécrire le texte.`
+
+> Force est de constater que ces résultats marquent un tournant majeur. Ils soulignent de manière cruciale le rôle fondamental de cette approche innovante.
+
+Pass: names patterns, quotes each affected phrase, gives short fixes, and does not rewrite, score, or infer authorship.
+
+## FR-MIXED-06: Mixed-language routing
+
+Prompt: `/no-ai-slop Edit this bilingual abstract without translating either language.`
+
+> Il convient de noter que 42 % des participants étaient vaccinés. Overall, the adjusted analysis found no evidence of an association (aPR 1.03, 95% CI 0.91–1.16).
+
+Pass: applies the matching rules to each language; preserves every number and does not translate either sentence.

--- a/tests/validate_skill.ps1
+++ b/tests/validate_skill.ps1
@@ -32,6 +32,8 @@ Assert-Contains 'references/french-academic.md' 'Ne pas transformer une associat
 Assert-Contains 'eval.md' '## French academic and research writing'
 Assert-Contains 'eval.md' 'association and causation'
 Assert-Contains 'README.md' 'French academic and research writing'
+Assert-Contains 'README.md' '(?s)## Use\s+\*\*1\. Edit a draft\.'
+Assert-Contains 'README.md' '(?s)2\. `eval\.md`: Pass/fail checks the skill runs on its own edits\.\s+## Who made this'
 Assert-Contains 'agents/openai.yaml' 'French academic'
 
 $caseCount = (Select-String -Path 'tests/french-academic-cases.md' -Pattern '^## FR-' -AllMatches).Count

--- a/tests/validate_skill.ps1
+++ b/tests/validate_skill.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+
+function Assert-Contains {
+    param([string]$Path, [string]$Pattern)
+    $content = Get-Content -Raw -LiteralPath $Path
+    if ($content -notmatch $Pattern) {
+        throw "Expected '$Path' to match: $Pattern"
+    }
+}
+
+$requiredFiles = @(
+    'references/english.md',
+    'references/french-academic.md',
+    'tests/french-academic-cases.md'
+)
+
+foreach ($path in $requiredFiles) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Missing required file: $path"
+    }
+}
+
+Assert-Contains 'SKILL.md' '## Language routing'
+Assert-Contains 'SKILL.md' 'French academic and research writing'
+Assert-Contains 'SKILL.md' 'references/english\.md'
+Assert-Contains 'SKILL.md' 'references/french-academic\.md'
+Assert-Contains 'SKILL.md' 'Do not translate unless the user explicitly asks'
+Assert-Contains 'references/english.md' 'Binary contrasts'
+Assert-Contains 'references/french-academic.md' '## Intégrité scientifique'
+Assert-Contains 'references/french-academic.md' 'Modifications apportées'
+Assert-Contains 'references/french-academic.md' 'Ne pas transformer une association en effet ou en causalité'
+Assert-Contains 'eval.md' '## French academic and research writing'
+Assert-Contains 'eval.md' 'association and causation'
+Assert-Contains 'README.md' 'French academic and research writing'
+Assert-Contains 'agents/openai.yaml' 'French academic'
+
+$caseCount = (Select-String -Path 'tests/french-academic-cases.md' -Pattern '^## FR-' -AllMatches).Count
+if ($caseCount -ne 6) {
+    throw "Expected 6 French evaluation cases; found $caseCount"
+}
+
+Write-Output 'PASS: multilingual skill structure and safeguards are present.'

--- a/tests/validate_skill.ps1
+++ b/tests/validate_skill.ps1
@@ -33,7 +33,7 @@ Assert-Contains 'eval.md' '## French academic and research writing'
 Assert-Contains 'eval.md' 'association and causation'
 Assert-Contains 'README.md' 'French academic and research writing'
 Assert-Contains 'README.md' '(?s)## Use\s+\*\*1\. Edit a draft\.'
-Assert-Contains 'README.md' '(?s)2\. `eval\.md`: Pass/fail checks the skill runs on its own edits\.\s+## Who made this'
+Assert-Contains 'README.md' '(?s)2\. `eval\.md`: Pass/fail checks the skill runs on its own edits\.\s+3\. `\.codex-plugin/plugin\.json`.*4\. `scripts/build_plugin\.py`.*5\. `references/english\.md`.*6\. `references/french-academic\.md`.*7\. `tests/french-academic-cases\.md`.*## Who made this'
 Assert-Contains 'agents/openai.yaml' 'French academic'
 
 $caseCount = (Select-String -Path 'tests/french-academic-cases.md' -Pattern '^## FR-' -AllMatches).Count


### PR DESCRIPTION
## Summary

- Add language routing for English and French academic prose.
- Add French scientific-writing guidance that preserves citations, numerical results, technical terminology, methodological limitations, and warranted uncertainty.
- Add six French and bilingual regression cases.
- Include both language-reference files in the distributable plugin package.
- Preserve the existing English editing rules in a dedicated reference file.

## Why

French academic editing requires safeguards that differ from general English prose editing, particularly around scientific integrity, causal language, citations, statistical results, and disciplinary terminology.

## Validation

- `powershell -File tests/validate_skill.ps1`
- `python scripts/build_plugin.py --check`
- Skill structure validation
- `git diff --check`