### PR TITLE
fix: scope plugin check cleanup

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -115,7 +115,12 @@ def main() -> None:
     validate_build(plugin_root, archive)
     print(f"Built {archive.relative_to(ROOT)}")
     if args.check:
-        shutil.rmtree(DIST)
+        shutil.rmtree(plugin_root)
+        archive.unlink()
+        try:
+            DIST.rmdir()
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ports and preserves the original contribution from #22 on an owner-controlled branch so the required validation workflow can run safely. The original commit author is preserved.\n\nValidation run locally:\n- /usr/bin/python3 scripts/build_plugin.py --check\n- git diff --check