### PR TITLE
Harden plugin workflow permissions

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -9,25 +9,39 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
       - name: Build plugin
         run: python scripts/build_plugin.py
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: no-ai-slop-plugin
           path: dist/no-ai-slop-plugin-*.zip
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download validated plugin
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: no-ai-slop-plugin
+          path: dist
       - name: Attach package to GitHub release
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release create "${GITHUB_REF_NAME}" dist/no-ai-slop-plugin-*.zip --generate-notes --verify-tag


### PR DESCRIPTION
## What changed

- Give validation only read access to repository contents.
- Move release write access into a separate tag-only job.
- Pin every GitHub Action to a verified full commit SHA.
- Release only the validated artifact produced by the read-only validation job.

## Why

The previous workflow granted contents write access to pull-request validation and used movable Action tags. This applies least privilege and immutable workflow dependencies.

## Validation

- Verified each SHA against the official actions repository tag.
- Parsed the workflow as YAML.
- Ran `/usr/bin/python3 scripts/build_plugin.py --check`.
- Ran `git diff --check`.
