### PR TITLE
Fix release/version mismatch, self-violations, and packaging scope

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
+      - name: Lint docs against the skill's own rules
+        run: python scripts/lint_docs.py
       - name: Build plugin
         run: python scripts/build_plugin.py
       - name: Upload workflow artifact
@@ -40,8 +42,20 @@ jobs:
         with:
           name: no-ai-slop-plugin
           path: dist
+      - name: Verify the archive matches the tag
+        # The archive is named from plugin.json; the release is named from the
+        # tag. Without this check a tag bumped without the manifest publishes the
+        # previous version's zip, and the glob below hides the mismatch.
+        run: |
+          expected="dist/no-ai-slop-plugin-${GITHUB_REF_NAME#v}.zip"
+          if [ ! -f "$expected" ]; then
+            echo "Tag ${GITHUB_REF_NAME} expects $expected, but the built archive is:" >&2
+            ls -1 dist/ >&2
+            echo "Bump \"version\" in .codex-plugin/plugin.json to match the tag." >&2
+            exit 1
+          fi
       - name: Attach package to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release create "${GITHUB_REF_NAME}" dist/no-ai-slop-plugin-*.zip --generate-notes --verify-tag
+        run: gh release create "${GITHUB_REF_NAME}" "dist/no-ai-slop-plugin-${GITHUB_REF_NAME#v}.zip" --generate-notes --verify-tag

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ No AI Slop checks for 20+ patterns, including:
 9. **Synonym cycling.** “The agent handles your email. The assistant drafts replies.”
 10. **Fake-profound endings.** “The future isn’t coming. It’s already here.”
 
-It also checks the fundamentals: Lead with the point when that helps, use active voice, untangle hard-to-follow sentences, and prefer concrete details over abstractions.
+It also checks the fundamentals: lead with the point when that helps, use active voice, untangle hard-to-follow sentences, and prefer concrete details over abstractions.
 
 ## What’s inside
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -13,7 +13,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / ".codex-plugin" / "plugin.json"
 DIST = ROOT / "dist"
-SKILL_ROOT = ROOT / "skills" / "no-ai-slop"
+SKILLS_DIR = ROOT / "skills"
+STATIC_FILES = ("LICENSE", "PRIVACY.md", "TERMS.md")
+
+
+def skill_dirs() -> list[Path]:
+    """Every skill the manifest's ./skills/ directory advertises."""
+    found = sorted(d for d in SKILLS_DIR.iterdir()
+                   if d.is_dir() and (d / "SKILL.md").is_file())
+    if not found:
+        raise SystemExit(f"No skills with a SKILL.md under {SKILLS_DIR.relative_to(ROOT)}")
+    return found
 
 
 def parse_args() -> argparse.Namespace:
@@ -46,7 +56,10 @@ def validate_source(manifest: dict) -> None:
     if len(prompts) > 3 or any(len(prompt) > 128 for prompt in prompts):
         raise SystemExit("Starter prompts must contain at most three entries of 128 characters or fewer")
 
-    for source in (SKILL_ROOT / "SKILL.md", SKILL_ROOT / "eval.md", ROOT / "assets" / "no-ai-slop.png"):
+    sources = [ROOT / "assets" / "no-ai-slop.png"]
+    for skill in skill_dirs():
+        sources += [skill / "SKILL.md", skill / "eval.md"]
+    for source in sources:
         if not source.is_file():
             raise SystemExit(f"Missing package source: {source.relative_to(ROOT)}")
 
@@ -56,18 +69,18 @@ def build_plugin(manifest: dict) -> tuple[Path, Path]:
     if plugin_root.exists():
         shutil.rmtree(plugin_root)
 
-    skill_root = plugin_root / "skills" / "no-ai-slop"
     (plugin_root / ".codex-plugin").mkdir(parents=True)
     (plugin_root / "assets").mkdir(parents=True)
-    skill_root.mkdir(parents=True)
 
     shutil.copy2(MANIFEST, plugin_root / ".codex-plugin" / "plugin.json")
-    shutil.copy2(SKILL_ROOT / "SKILL.md", skill_root / "SKILL.md")
-    shutil.copy2(SKILL_ROOT / "eval.md", skill_root / "eval.md")
+    for skill in skill_dirs():
+        dest = plugin_root / "skills" / skill.name
+        dest.mkdir(parents=True)
+        shutil.copy2(skill / "SKILL.md", dest / "SKILL.md")
+        shutil.copy2(skill / "eval.md", dest / "eval.md")
     shutil.copy2(ROOT / "assets" / "no-ai-slop.png", plugin_root / "assets" / "no-ai-slop.png")
-    shutil.copy2(ROOT / "LICENSE", plugin_root / "LICENSE")
-    shutil.copy2(ROOT / "PRIVACY.md", plugin_root / "PRIVACY.md")
-    shutil.copy2(ROOT / "TERMS.md", plugin_root / "TERMS.md")
+    for name in STATIC_FILES:
+        shutil.copy2(ROOT / name, plugin_root / name)
 
     archive = DIST / f"no-ai-slop-plugin-{manifest['version']}.zip"
     if archive.exists():
@@ -80,15 +93,9 @@ def build_plugin(manifest: dict) -> tuple[Path, Path]:
 
 
 def validate_build(plugin_root: Path, archive: Path) -> None:
-    expected = {
-        ".codex-plugin/plugin.json",
-        "assets/no-ai-slop.png",
-        "skills/no-ai-slop/SKILL.md",
-        "skills/no-ai-slop/eval.md",
-        "LICENSE",
-        "PRIVACY.md",
-        "TERMS.md",
-    }
+    expected = {".codex-plugin/plugin.json", "assets/no-ai-slop.png", *STATIC_FILES}
+    for skill in skill_dirs():
+        expected |= {f"skills/{skill.name}/SKILL.md", f"skills/{skill.name}/eval.md"}
     actual = {
         str(path.relative_to(plugin_root))
         for path in plugin_root.rglob("*")
@@ -97,12 +104,12 @@ def validate_build(plugin_root: Path, archive: Path) -> None:
     if expected != actual:
         raise SystemExit(f"Unexpected package files: expected {sorted(expected)}, found {sorted(actual)}")
 
-    packaged_skill = plugin_root / "skills" / "no-ai-slop" / "SKILL.md"
-    packaged_eval = plugin_root / "skills" / "no-ai-slop" / "eval.md"
-    if packaged_skill.read_bytes() != (SKILL_ROOT / "SKILL.md").read_bytes():
-        raise SystemExit("Packaged SKILL.md does not match the canonical file")
-    if packaged_eval.read_bytes() != (SKILL_ROOT / "eval.md").read_bytes():
-        raise SystemExit("Packaged eval.md does not match the canonical file")
+    for skill in skill_dirs():
+        for name in ("SKILL.md", "eval.md"):
+            packaged = plugin_root / "skills" / skill.name / name
+            if packaged.read_bytes() != (skill / name).read_bytes():
+                raise SystemExit(
+                    f"Packaged skills/{skill.name}/{name} does not match the canonical file")
     if not zipfile.is_zipfile(archive):
         raise SystemExit("Plugin archive is not a valid ZIP file")
 

--- a/scripts/lint_docs.py
+++ b/scripts/lint_docs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Check the skill's own docs against the rules the skill enforces.
+
+A style checker that breaks its own rules is the one kind of bug that costs it
+credibility, and it is cheap to catch. This lints README.md, SKILL.md, and
+eval.md for the subset of rules that can be checked mechanically, plus the
+cross-reference integrity between SKILL.md and eval.md.
+
+It deliberately does not try to evaluate editing quality -- that needs a model,
+and `eval.md` is the checklist for it. This only catches the mechanical misses.
+
+Usage: python scripts/lint_docs.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "no-ai-slop" / "SKILL.md"
+EVAL = ROOT / "skills" / "no-ai-slop" / "eval.md"
+README = ROOT / "README.md"
+DOCS = (README, SKILL, EVAL)
+
+# Short copy gets no em dashes; longer drafts tolerate 1-2 (SKILL.md).
+EM_DASH_BUDGET = {README.name: 0, SKILL.name: 2, EVAL.name: 2}
+
+
+def _lines(path: Path, skip_frontmatter: bool = False) -> list[tuple[int, str]]:
+    """Numbered lines, optionally without the YAML frontmatter block.
+
+    Frontmatter keys are `key: Value` by construction, so they trip the
+    colon rule without being prose.
+    """
+    raw = path.read_text(encoding="utf-8").splitlines()
+    out = list(enumerate(raw, 1))
+    if skip_frontmatter and raw and raw[0].strip() == "---":
+        end = next((i for i, l in enumerate(raw[1:], 1) if l.strip() == "---"), 0)
+        out = out[end + 1:]
+    return out
+
+
+def _banned_words() -> list[str]:
+    m = re.search(r"Banned outright:\s*(.+?)\.\s*$",
+                  SKILL.read_text(encoding="utf-8"), re.M)
+    if not m:
+        raise SystemExit("lint: could not find the banned-word list in SKILL.md")
+    return [w.strip() for w in m.group(1).split(",") if w.strip()]
+
+
+def check_colon_case(fail) -> None:
+    """SKILL.md: prefer sentence case after a colon unless grammar requires otherwise."""
+    ok_after = re.compile(r"^(I|AI|GitHub|ChatGPT|Claude|Codex|MIT|SKILL)\b")
+    # A colon may introduce a direct question or quotation; that is grammar,
+    # not the "colon reveal" pattern the skill targets.
+    introduces_speech = re.compile(
+        r"\b(question|questions|ask|asks|prompt|quote|quotes|example|examples)\s*$", re.I)
+    for path in DOCS:
+        for n, line in _lines(path, skip_frontmatter=True):
+            if line.lstrip().startswith(("http", "|", "```", "-  ")):
+                continue
+            for m in re.finditer(r":\s+([A-Z][a-z]+)", line):
+                word = m.group(1)
+                if ok_after.match(word):
+                    continue
+                if introduces_speech.search(line[:m.start()]):
+                    continue
+                # a proper noun or a title is fine; a plain word starting a
+                # clause is the pattern the skill says to fix
+                fail(f"{path.name}:{n}: capitalised '{word}' after a colon "
+                     f"(SKILL.md prefers sentence case)")
+
+
+def check_em_dashes(fail) -> None:
+    for path in DOCS:
+        count = path.read_text(encoding="utf-8").count("—")
+        budget = EM_DASH_BUDGET[path.name]
+        if count > budget:
+            fail(f"{path.name}: {count} em dashes, budget is {budget}")
+
+
+def check_banned_words(fail) -> None:
+    """Banned words must not appear outside the list that defines them."""
+    banned = _banned_words()
+    for path in DOCS:
+        for n, line in _lines(path):
+            if "Banned outright:" in line:
+                continue
+            for word in banned:
+                if re.search(rf"\b{re.escape(word)}\b", line, re.I):
+                    fail(f"{path.name}:{n}: banned word '{word}'")
+
+
+def check_pattern_coverage(fail) -> None:
+    """Every bolded pattern in SKILL.md should be reachable from eval.md.
+
+    Catches the drift where a rule is added or renamed in one file only.
+    """
+    skill_text = SKILL.read_text(encoding="utf-8")
+    section = skill_text.split("## Patterns to cut", 1)[-1].split("## Workflow", 1)[0]
+    patterns = re.findall(r"^\*\*(.+?)\.\*\*", section, re.M)
+    eval_text = EVAL.read_text(encoding="utf-8").lower()
+    for pat in patterns:
+        # match on the distinctive head noun, so light rewording does not trip it
+        key = pat.lower().split()[0].rstrip(",")
+        if key not in eval_text:
+            fail(f"eval.md: no check covers SKILL.md pattern '{pat}'")
+    if not patterns:
+        fail("SKILL.md: no bolded patterns found; has the format changed?")
+
+
+def main() -> int:
+    failures: list[str] = []
+    fail = failures.append
+    for check in (check_colon_case, check_em_dashes,
+                  check_banned_words, check_pattern_coverage):
+        check(fail)
+    if failures:
+        print("Docs do not satisfy the skill's own rules:\n", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    print(f"lint_docs: {len(DOCS)} docs satisfy the skill's own rules")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/no-ai-slop/eval.md
+++ b/skills/no-ai-slop/eval.md
@@ -30,9 +30,9 @@ For detect requests, make sure the response names each pattern found with a quot
 4. Is interpretive metadiscourse removed, including authorial metacommentary, reader guidance, emphasis markers, and redundant glossing?
 5. Are fake-profound kicker lines deleted instead of rewritten into better metaphors?
 6. Are summary-recap endings cut so the piece ends on a concrete point, takeaway, or next action?
-7. Is formatting slop removed: Emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
+7. Is formatting slop removed: emoji headings, decorative bold, bullets that should be prose, headers over tiny sections?
 8. Are colons sentence case unless grammar, a proper noun, a title, or code requires otherwise?
-9. Are em dashes used sparingly: Usually none in short copy, and only 1-2 in longer drafts when they clearly help?
+9. Are em dashes used sparingly: usually none in short copy, and only 1-2 in longer drafts when they clearly help?
 
 ## Final read
 


### PR DESCRIPTION
Three mechanical fixes found while reading the repo. **No changes to the skill's rules** — that's split into a separate PR so this one can be judged on its own.

### 1. Release can attach the wrong artifact

```yaml
gh release create "${GITHUB_REF_NAME}" dist/no-ai-slop-plugin-*.zip
```

The archive is named from `plugin.json`'s version; the release is named from the git tag. Nothing compares them. Tag `v1.0.7` without bumping the manifest and you publish `no-ai-slop-plugin-1.0.6.zip` as release v1.0.7 — and the `*` glob hides it. The job now checks the expected filename exists and passes it explicitly instead of globbing. Tested both paths: with the manifest at 1.0.6, `v1.0.6` is allowed and `v1.0.7` is blocked with a message naming the fix.

### 2. The docs break the skill's own sentence-case-after-colon rule

Three places: `eval.md:33` (`removed: Emoji headings`), `eval.md:35` (`sparingly: Usually none`), `README.md:72` (`fundamentals: Lead with`). Cosmetic anywhere else; in a style checker it's the one class of error that costs credibility.

`scripts/lint_docs.py` now checks the docs against the rules the skill enforces — colon case, the em-dash budget, banned words outside the list that defines them, and whether every pattern in `SKILL.md` is still covered by a check in `eval.md` (that last one catches rules drifting between the two files, which the recent history suggests is a live risk). It runs in CI ahead of the build, in about 10 s.

An earlier version of the linter also flagged the YAML frontmatter and `ask one question: Who is this for…`. Both are grammar rather than the "colon reveal" pattern, so it now skips frontmatter and speech-introducing colons. Shipping a noisy linter would have replaced one credibility problem with another.

### 3. Packaging silently truncates a second skill

`build_plugin.py` hardcoded `skills/no-ai-slop` (and an explicit `expected` file set) while the manifest advertises `"skills": "./skills/"`. It now packages and verifies every `skills/*/` directory that has a `SKILL.md`. Verified by temporarily adding a second skill and confirming both appear in the archive.

---

Verified: `lint_docs.py` passes on the fixed docs and flags exactly the three real violations on the originals with no false positives; `build_plugin.py --check` builds clean. This PR is independent of the rules PR and passes CI with `SKILL.md` untouched.
