### PR TITLE
Reconcile the fragment rule with the editing principles

### DIFF
--- a/skills/no-ai-slop/SKILL.md
+++ b/skills/no-ai-slop/SKILL.md
@@ -51,6 +51,8 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 ## Patterns to cut
 
+These patterns are defaults, not overrides. Where a pattern below conflicts with the editing principles above, the principles win: keep the line when it carries the writer's real voice.
+
 **Binary contrasts.** "This is not X. It's Y." / "The question isn't X, it's Y." / "It's not just X but Y." State Y directly. "The question isn't the model. It's the eval." becomes "The eval matters more than the model."
 
 **Throat-clearing openers.** "Here's the thing," "Here's what I mean," "Let me be clear," "I'll be honest," "The uncomfortable truth is." Cut them and state the point.
@@ -73,7 +75,7 @@ Often-empty phrases: it's worth noting, it's important to note, at the end of th
 
 **Negative listing.** "Not a X. Not a Y. A Z." Just say Z.
 
-**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Use complete sentences.
+**Dramatic fragmentation.** "X. And Y. And Z." or "That's it. That's the whole thing." Restore complete sentences when fragments are stacked for rhythm or drama. A single fragment that matches how the writer talks is voice, not slop, and the editing principles above take precedence.
 
 **Robotic rhythm.** Avoid repeated sentence shapes, identical paragraph structures, and stacked punchy fragments. Vary the shape only when it helps the point.
 


### PR DESCRIPTION
A judgment call about the skill's own rules rather than a defect, so it is split from the mechanical fixes (#37) and can be declined independently.

**The Patterns and Editing principles sections contradict each other on fragments.**

Editing principles:
> Keep longer spoken sentences, **fragments**, and changes in pace when they are clear and characteristic of the writer.

Patterns to cut:
> **Dramatic fragmentation.** … Use complete sentences.

An agent reading the Patterns list literally deletes exactly what the principles protect. The Patterns entries read as absolutes while the principles are conditional, and nothing in the file says which wins.

**Proposed fix, kept minimal:**

1. Narrow the fragment rule to *stacked* fragments used for rhythm or drama. That looks like the original intent, since "Robotic rhythm" already covers repeated shapes separately — so the current wording seems to over-reach rather than to disagree.
2. State once, at the top of the Patterns section, that the principles take precedence where the two conflict.

I deliberately did not touch any other pattern. If you'd rather resolve this the other way — tightening the principle instead of loosening the pattern — that works equally well for the contradiction; the point is only that an agent currently gets opposite instructions from the same file.

Passes `lint_docs.py` and the build once #37 is in (verified by applying this change on top of that branch); on its own it fails only on the doc violations that #37 fixes.
